### PR TITLE
quick typo fixes

### DIFF
--- a/public/group_rules.html
+++ b/public/group_rules.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.00"/>
     </head>
     <body style="text-align: left">
-        <h1>About GNU/Weeb</h2>
+        <h1>About GNU/Weeb</h1>
 
         <h2>Communication hub for anime and GNU/Linux enthusiasts.</h2>
         <br/>
@@ -77,3 +77,5 @@
         <h3>GNU/Weeb Notes</h3>
 
         <p>1. If you have anything to say about our group, feel free to contact <a href="https://t.me/Ryne4S">@Ryne4S</a></p>
+    </body>
+</html>


### PR DESCRIPTION
quick typo fixes and a missing html closing. resulted on the group rules page being white backgrounded and broken (which didn't happen locally, odd)
another suspect: css not loading properly (?)